### PR TITLE
Add discord slash commands and handbook

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,6 +5,7 @@
   },
   "imports": {
     "@deno/kv-oauth": "jsr:@deno/kv-oauth@^0.11.0",
+    "@discord-applications/app": "jsr:@discord-applications/app@^0.0.4",
     "@std/assert": "jsr:@std/assert@1",
     "discord-api-types": "npm:discord-api-types@^0.37.112"
   }

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@deno/kv-oauth@*": "0.11.0",
     "jsr:@deno/kv-oauth@0.11": "0.11.0",
+    "jsr:@discord-applications/app@^0.0.4": "0.0.4",
     "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@1": "1.0.9",
     "jsr:@std/async@0.221": "0.221.0",
@@ -16,7 +17,9 @@
     "jsr:@std/path@0.221": "0.221.0",
     "jsr:@std/streams@0.221": "0.221.0",
     "npm:discord-api-types@*": "0.37.112",
-    "npm:discord-api-types@~0.37.112": "0.37.112"
+    "npm:discord-api-types@0.37.79": "0.37.79",
+    "npm:discord-api-types@~0.37.112": "0.37.112",
+    "npm:tweetnacl@^1.0.3": "1.0.3"
   },
   "jsr": {
     "@deno/kv-oauth@0.11.0": {
@@ -24,6 +27,13 @@
       "dependencies": [
         "jsr:@std/datetime",
         "jsr:@std/http"
+      ]
+    },
+    "@discord-applications/app@0.0.4": {
+      "integrity": "fa95279d13d2ad07636799d12dd637d930a6443a0d4223e9f65493a58cb47dd5",
+      "dependencies": [
+        "npm:discord-api-types@0.37.79",
+        "npm:tweetnacl"
       ]
     },
     "@std/assert@0.221.0": {
@@ -88,11 +98,18 @@
   "npm": {
     "discord-api-types@0.37.112": {
       "integrity": "sha512-DDEt3696k7o9+Ot2a5phqsEKnwhSGfIDzXJR9V5OMba9fbvJOEhPapLXy645RkrGCEKZeoFd3qXFhrvVQSUbxQ=="
+    },
+    "discord-api-types@0.37.79": {
+      "integrity": "sha512-jblKMZL5f9t/pfUyhHNey8Lb9yVCcBVIPxz/JTY0raAmfj7CuFXdl9m5o/+iiB7E0vv1Kz9V7Ao5HtLRc2gH1Q=="
+    },
+    "tweetnacl@1.0.3": {
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@deno/kv-oauth@0.11",
+      "jsr:@discord-applications/app@^0.0.4",
       "jsr:@std/assert@1",
       "npm:discord-api-types@~0.37.112"
     ]

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -51,4 +51,4 @@ Invites Isabot to your Discord server.
 ## Current Limitations
 
 The only way to update your list of characters with Isabot is to sign in again with your Battle.net account. Due to the limitations of the Blizzard API, there is no way to 
-update data automatically. 
+update your character list automatically. 

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -1,0 +1,54 @@
+# isabot official handbook!
+
+## Abstract
+
+This handbook contains the relevant information on the leaderboard system for Isabot. Join the AR Club Discord server and guild on Bronzebeard-Shandris to join in on the fun.
+
+## Privacy
+
+Isabot stores the following information upon a successful sign-in:
+
+1. WoW characters that are in Bronzebeard-Shandris *and* the AR Club guild. Specifically, the character name, id, and realm name, slug name, and id. 
+2. Your account battle tags *without* the unique identifier.
+3. Number of mounts in account-wide collection
+
+Your WoW characters are used to update the fields you are competing in (i.e mounts, etc). 
+
+## Leaderboard
+
+The leaderboard is composed of leaderboard entries. Each entry contains the players that signed up for the leaderboard and the fields they are competing in, such as
+the highest amount of mounts, etc (more fields will come soon). An entry is created and sent to the Discord server every Sunday at 20:00 UTC. To ensure that each field for each player is accurate, the system updates your data in the database weekly using the characters given.
+
+
+## Discord Slash Commands
+
+### `/lb cmd latest`
+
+Gets the latest leaderboard entry. 
+
+## Website Pages 
+
+### `/lb`
+
+Gets all leaderboard entries. 
+
+### `/lb/latest`
+
+Gets the latest leaderboard entry. 
+
+### `/signin`
+
+Sign in with Isabot using your Battle.net account.
+
+### `/signout`
+
+Sign out of Isabot.
+
+### `/invite`
+
+Invites Isabot to your Discord server.
+
+## Current Limitations
+
+The only way to update your list of characters with Isabot is to sign in again with your Battle.net account. Due to the limitations of the Blizzard API, there is no way to 
+update data automatically. 

--- a/leaderboard/update-leaderboard.ts
+++ b/leaderboard/update-leaderboard.ts
@@ -1,1 +1,0 @@
-// Cron job that will update the leaderboard weekly and send it via Discord webhooks

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -1,0 +1,82 @@
+import type { AppSchema } from "@discord-applications/app";
+import {
+  createApp,
+  InteractionResponseType,
+  MessageFlags,
+} from "@discord-applications/app";
+import { Leaderboard } from "../leaderboard/lb.ts";
+import { LeaderboardEntry } from "../leaderboard/types.d.ts";
+
+export const isabotSchema = {
+  chatInput: {
+    name: "isabot",
+    description: "Very cool commands for isabot",
+    groups: {
+      lb: {
+        description: "Leaderboard commands",
+        subcommands: {
+          latest: {
+            description: "Get the latest leaderboard entry",
+            // Leave options empty if no options needed
+            options: {},
+          },
+          all: {
+            description: "Get all leaderboard entries",
+            options: {},
+          },
+        },
+      },
+    },
+  },
+} as const satisfies AppSchema;
+
+export const discordAppHandler = createApp({
+  schema: isabotSchema,
+  applicationID: Deno.env.get("DISCORD_APP_ID")!,
+  publicKey: Deno.env.get("DISCORD_PUBLIC_KEY")!,
+  token: Deno.env.get("DISCORD_TOKEN")!,
+  register: true,
+  invite: { path: "/invite", scopes: ["applications.commands"] },
+}, {
+  lb: {
+    // @ts-ignore: ignore weird typing error with discord app library
+    latest: async (_interaction) => {
+      const entry = await Leaderboard.getLatestEntry();
+      return sendMsg(formatLeaderboardData(entry));
+    },
+    // @ts-ignore: ignore weird typing error with discord app library
+    all: async (_interaction) => {
+      const entries = await Leaderboard.getEntries();
+      return sendMsg(entries.map(formatLeaderboardData).join("\n"));
+    },
+  },
+});
+
+export const sendMsg = (message: string) => {
+  return {
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      content: message,
+      // Ensure only the user who invoked the command can see the message
+      // so it doesn't flood text channels with bot command outputs
+      flags: MessageFlags.Ephemeral,
+    },
+  };
+};
+
+export const formatLeaderboardData = (entry: LeaderboardEntry): string => {
+  const lines: string[] = [];
+
+  lines.push(`🏆 Leaderboard Entry: ${entry.entry_id}`);
+  lines.push(`📅 Date: ${new Date(entry.date_added).toLocaleDateString()}\n`);
+
+  Object.entries(entry.players).forEach(([playerId, player]) => {
+    const playerMounts = entry.mounts[playerId]?.number_of_mounts ?? 0;
+    lines.push(`👤 ${player.battletag}`);
+    lines.push(`   🐎 Mounts: ${playerMounts}`);
+  });
+
+  // Join all lines with newlines
+  // Discord messages have a 2000 character limit
+  return lines.join("\n").slice(0, 2000);
+};

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -22,11 +22,12 @@ export const isabotSchema = {
             // Leave options empty if no options needed
             options: {},
           },
-          all: {
-            description: "Get all leaderboard entries",
-            // Leave options empty if no options needed
-            options: {},
-          },
+          // TODO: Implement other slash commands?
+          // all: {
+          //   description: "Get all leaderboard entries",
+          //   // Leave options empty if no options needed
+          //   options: {},
+          // },
         },
       },
     },
@@ -60,16 +61,16 @@ export const createDiscordApp = (
         return handleLeaderboardCommand([entry]);
       },
       // @ts-ignore: ignore weird typing error with discord app library
-      all: async (_interaction) => {
-        if (Deno.env.get("ENV") === "dev") {
-          return handleLeaderboardCommand([
-            dummyLeaderboardEntry,
-            dummyLeaderboardEntry,
-          ]);
-        }
-        const entries = await Leaderboard.getEntries();
-        return handleLeaderboardCommand(entries);
-      },
+      // all: async (_interaction) => {
+      //   if (Deno.env.get("ENV") === "dev") {
+      //     return handleLeaderboardCommand([
+      //       dummyLeaderboardEntry,
+      //       dummyLeaderboardEntry,
+      //     ]);
+      //   }
+      //   const entries = await Leaderboard.getEntries();
+      //   return handleLeaderboardCommand(entries);
+      // },
     },
   });
 };

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -40,13 +40,14 @@ export const createDiscordApp = (
   path: string,
 ) => {
   return createApp({
+    // https://jsr.io/@discord-applications/app/doc/~/AppHandlerOptions
     schema: isabotSchema,
     applicationID: discordApplicationID,
     publicKey: discordPublicKey,
     token: discordToken,
     register: true,
     path: path,
-    // prob not needed
+    // prob not needed since it's handled by the other handler, but leaving it here
     invite: { path: "/invite", scopes: ["applications.commands"] },
   }, {
     cmd: {
@@ -104,7 +105,7 @@ export const sendMsg = (message: string): APIInteractionResponse => {
   };
 };
 
-function formatLeaderboardData(entries: LeaderboardEntry[]): string {
+export const formatLeaderboardData = (entries: LeaderboardEntry[]): string => {
   const DISCORD_MAX_LENGTH = 2000;
 
   if (!entries || entries.length === 0) {
@@ -144,14 +145,13 @@ function formatLeaderboardData(entries: LeaderboardEntry[]): string {
         lines.push(`   🐎 Mounts: ${playerMounts}`);
       });
     }
-
     return lines.join("\n");
   });
 
   return formattedEntries.join("\n\n").slice(0, DISCORD_MAX_LENGTH);
-}
+};
 
-const handleLeaderboardCommand = (
+export const handleLeaderboardCommand = (
   entries: LeaderboardEntry[],
 ): APIInteractionResponse => {
   const formattedMessage = formatLeaderboardData(entries);

--- a/main.ts
+++ b/main.ts
@@ -266,6 +266,10 @@ const handler = async (req: Request) => {
       return Response.redirect(
         discordInviteUrl(Deno.env.get("DISCORD_APPLICATION_ID") as string),
       );
+    case "/code": {
+      const github = "https://github.com/johncmanuel/isabot";
+      return Response.redirect(github);
+    }
     default:
       return new Response("Not Found", { status: 404 });
   }

--- a/main.ts
+++ b/main.ts
@@ -17,7 +17,11 @@ import { getExpirationDate } from "./lib/utils.ts";
 import { GUILD_REALM, GUILD_SLUG_NAME } from "./lib/consts.ts";
 import { Leaderboard } from "./leaderboard/lb.ts";
 import { dummyLeaderboardEntry } from "./leaderboard/dummyData.ts";
-import { createDiscordApp, withErrorResponse } from "./lib/discord.ts";
+import {
+  createDiscordApp,
+  discordInviteUrl,
+  withErrorResponse,
+} from "./lib/discord.ts";
 
 // Order of Deno Cron executions
 // 1. Update Guild Data
@@ -261,6 +265,10 @@ const handler = async (req: Request) => {
       return new Response("Not found", { status: 404 });
     case "/discord":
       return withErrorResponse(app)(req);
+    case "/invite":
+      return Response.redirect(
+        discordInviteUrl(Deno.env.get("DISCORD_APPLICATION_ID") as string),
+      );
     default:
       return new Response("Not Found", { status: 404 });
   }

--- a/main.ts
+++ b/main.ts
@@ -17,6 +17,7 @@ import { getExpirationDate } from "./lib/utils.ts";
 import { GUILD_REALM, GUILD_SLUG_NAME } from "./lib/consts.ts";
 import { Leaderboard } from "./leaderboard/lb.ts";
 import { dummyLeaderboardEntry } from "./leaderboard/dummyData.ts";
+import { createDiscordApp, withErrorResponse } from "./lib/discord.ts";
 
 // Order of Deno Cron executions
 // 1. Update Guild Data
@@ -92,6 +93,12 @@ const handler = async (req: Request) => {
   const { pathname } = new URL(req.url);
   const { handleCallback, getSessionId, signIn, signOut } = createOAuthHelpers(
     req,
+  );
+  const app = await createDiscordApp(
+    Deno.env.get("DISCORD_APPLICATION_ID") as string,
+    Deno.env.get("DISCORD_PUBLIC_KEY") as string,
+    Deno.env.get("DISCORD_TOKEN") as string,
+    "/discord",
   );
 
   switch (pathname) {
@@ -243,15 +250,17 @@ const handler = async (req: Request) => {
     case "/test":
       if (Deno.env.get("ENV") === "dev") {
         // await updateGuildData();
-        await Leaderboard.sendMountLBtoDiscord(
-          Deno.env.get("DISCORD_WEBHOOK_URL") as string,
-          dummyLeaderboardEntry,
-          `${getBaseUrl(req)}/signin`,
-        );
-        // await updateAllPlayersData();
+        // await Leaderboard.sendMountLBtoDiscord(
+        //   Deno.env.get("DISCORD_WEBHOOK_URL") as string,
+        //   dummyLeaderboardEntry,
+        //   `${getBaseUrl(req)}/signin`,
+        // );
+        await updateAllPlayersData();
         return new Response("Updated guild data, other stuff too");
       }
       return new Response("Not found", { status: 404 });
+    case "/discord":
+      return withErrorResponse(app)(req);
     default:
       return new Response("Not Found", { status: 404 });
   }

--- a/main.ts
+++ b/main.ts
@@ -200,10 +200,7 @@ const handler = async (req: Request) => {
             }))
           );
 
-          const res2 = await kv.atomic().check({
-            key: charKey,
-            versionstamp: null,
-          })
+          const res2 = await kv.atomic()
             .set(charKey, playerCharacters)
             .commit();
           if (res2.ok) {


### PR DESCRIPTION
The only way to view the current leaderboard without the webhook is through the `/lb` or `/lb/latest` endpoints. Though it is machine-readable, it is not human-readable. Discord slash commands will allow the players on Discord to view the leaderboard data in a more readable form. 

Slash commands:

1. /lb user latest - gets the latest entry in the leaderboard.

More slash commands may be added, such as getting the leaderboard for a specific field (i.e mounts, number of mythic wins, etc). 

In the project structure, there is a handbook under `/docs` for how to use these commands, privacy policies, and other relevant information for the end user. 